### PR TITLE
Fix call to undefined function GuzzleHttp\choose_handler()

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -12,6 +12,14 @@ use Composer\Command\BaseCommand;
 use Symfony\Component\Yaml\Yaml;
 use TQ\Git\Repository\Repository;
 
+$autoloader = __DIR__ . '/../../../../vendor/autoload.php';
+if (!file_exists($autoloader)) {
+    echo 'Directory "vendor" does not exist. Run "composer install".';
+    exit(1);
+}
+
+require $autoloader;
+
 /**
  * Class Command
  *


### PR DESCRIPTION
Add autoloader to Command class.

Composer isn't using the vendor/autoload.php file for plugins/command
files. This fixes the error:

PHP Fatal error:  Uncaught Error: Call to undefined function GuzzleHttp\choose_handler()